### PR TITLE
Handle nil ranges better; Use Ruby 3.1

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,7 +22,7 @@ jobs:
           - 18101:5432
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.1', '3.0', '2.7']
+        ruby-version: ['3.3', '3.2', '3.1']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
-require:
+plugins:
   - rubocop-sequel
 
 AllCops:
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
 
 Gemspec/DevelopmentDependencies:
   EnforcedStyle: gemspec
@@ -66,24 +66,16 @@ Lint/EmptyBlock:
 Lint/UselessAssignment:
   Exclude:
     - 'spec/**/*'
-Lint/UnusedMethodArgument:
-  Exclude:
-    - 'lib/webhookdb/replicator/base.rb'
-    - 'spec/support/*.rb'
 
 # https://rubocop.readthedocs.io/en/latest/cops_naming/
 Naming/AccessorMethodName:
   Enabled: false
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Exclude:
     - 'spec/**/*'
-    - 'lib/webhookdb/spec_helpers.rb'
-    - 'lib/webhookdb/spec_helpers/*.rb'
 Naming/MethodParameterName:
   Enabled: false
 
-Sequel/ColumnDefault:
-  Enabled: false
 Sequel/ConcurrentIndex:
   Enabled: false
 
@@ -102,10 +94,6 @@ Style/Documentation:
   Enabled: false
 Style/FormatString:
   EnforcedStyle: percent
-Style/NumericPredicate:
-  AllowedMethods: ['where']
-  Exclude:
-    - 'db/migrations/*'
 Style/RedundantReturn:
   Enabled: false
 Style/RedundantSelf:

--- a/lib/sequel/plugins/tstzrange_fields.rb
+++ b/lib/sequel/plugins/tstzrange_fields.rb
@@ -87,7 +87,7 @@ module Sequel
             when Float::INFINITY
               range = Sequel::Postgres::PGRange.new(nil, nil, empty: false, db_type: :tstzrange)
               self[column] = range
-            when "empty"
+            when "empty", nil
               self[column] = Sequel::Postgres::PGRange.empty(:tstzrange)
           else
               beg = value.respond_to?(:begin) ? value.begin : (value[:begin] || value["begin"])
@@ -97,7 +97,8 @@ module Sequel
         end
 
         model.define_method(get_begin_method) do
-          send(get_column_method).begin
+          r = send(get_column_method)
+          return r&.begin
         end
 
         model.define_method(set_begin_method) do |new_time|

--- a/lib/sequel/plugins/tstzrange_fields.rb
+++ b/lib/sequel/plugins/tstzrange_fields.rb
@@ -70,11 +70,11 @@ module Sequel
 
       def self.create_accessors(model, column)
         get_column_method = column.to_sym
-        set_column_method = "#{column}=".to_sym
-        get_begin_method = "#{column}_begin".to_sym
-        set_begin_method = "#{column}_begin=".to_sym
-        get_end_method = "#{column}_end".to_sym
-        set_end_method = "#{column}_end=".to_sym
+        set_column_method = :"#{column}="
+        get_begin_method = :"#{column}_begin"
+        set_begin_method = :"#{column}_begin="
+        get_end_method = :"#{column}_end"
+        set_end_method = :"#{column}_end="
 
         model.define_method(get_column_method) do
           self[column]

--- a/lib/sequel_tstzrange_fields/version.rb
+++ b/lib/sequel_tstzrange_fields/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SequelTstzrangeFields
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/sequel-tstzrange-fields.gemspec
+++ b/sequel-tstzrange-fields.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/lithictech/sequel-tstzrange-fields"
   spec.summary = "Gem for enabling time ranges when working with postgres"
   spec.license = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
   spec.description = <<~DESC
     Gem for enabling time ranges when working with postgres
   DESC

--- a/spec/sequel/plugins/tstzrange_fields_spec.rb
+++ b/spec/sequel/plugins/tstzrange_fields_spec.rb
@@ -174,6 +174,23 @@ RSpec.describe Sequel::Plugins::TstzrangeFields do
       expect(o.range).to be_cover(from_now(30, minute))
     end
 
+    it "creates an empty range for a nil value" do
+      o = model_class.create(range: nil)
+      expect(o.range).to_not be_nil
+    end
+
+    it "can initialize an instance with a nil range" do
+      o = model_class.new
+      o[:range] = nil
+      expect(o.range).to be_nil
+      t = Time.now
+      o.range_end = t
+      expect(o.range).to have_attributes(begin: nil, end: t)
+      o[:range] = nil
+      o.range_begin = t
+      expect(o.range).to have_attributes(begin: t, end: nil)
+    end
+
     it "can be assigned to directly with an object with begin/end methods or keys" do
       early = ago(1, day)
       late = from_now(2, day)


### PR DESCRIPTION
Use Ruby 3.1 as min version

---

Handle nil ranges better

Models that do not initialize their range in their `initialize`
method could error if setting their `<range>_end`
before `<range>_begin`. This makes sure the plugin
works even if the range column is nil.
